### PR TITLE
Fixing Android buid error

### DIFF
--- a/android/src/main/kotlin/saad/farhan/flutter_facebook_sdk/FlutterFacebookSdkPlugin.kt
+++ b/android/src/main/kotlin/saad/farhan/flutter_facebook_sdk/FlutterFacebookSdkPlugin.kt
@@ -255,7 +255,7 @@ class FlutterFacebookSdkPlugin : FlutterPlugin, MethodCallHandler, StreamHandler
 
     }
 
-    override fun onNewIntent(intent: Intent?): Boolean {
+    override fun onNewIntent(intent: Intent): Boolean {
         try {
             // some code
             deepLinkUrl = AppLinks.getTargetUrl(intent).toString()


### PR DESCRIPTION
onNewIntent not matching the original override